### PR TITLE
Fix collision when sliding against a wall in some directions

### DIFF
--- a/src/modules/player.js
+++ b/src/modules/player.js
@@ -25,7 +25,7 @@ class Player {
           / | \
         SW  S  SE
     */
-    move(dir, entities) {
+    move(dir, unsortedEntities) {
         const DIAGONAL_SPEED_MODIFIER = 1.41;
 
         let newX = this.x;
@@ -70,6 +70,35 @@ class Player {
                 newY = newY - (this.speed / DIAGONAL_SPEED_MODIFIER);
                 break;
         }
+
+        let sortedWallEntities = [];
+
+        // SORT WALLS FOR COLLISIONS
+        if (dir != undefined && dir != null) {
+            // Loop through all unsortedEntities
+            for (let i = 0; i < unsortedEntities.length; i++) {
+                // Handle wall collision
+                if (unsortedEntities[i].name == "wall") {
+                    let colliding_on_x_axis = (newX + this.size > unsortedEntities[i].x) && (newX < unsortedEntities[i].x + unsortedEntities[i].size);
+                    let colliding_on_y_axis = (newY + this.size > unsortedEntities[i].y) && (newY < unsortedEntities[i].y + unsortedEntities[i].size);
+                    let colliding = colliding_on_x_axis && colliding_on_y_axis;
+
+                    if (colliding) {
+                        let xDiff = Math.abs(newX - unsortedEntities[i].x);
+                        let yDiff = Math.abs(newY - unsortedEntities[i].y);
+
+                        sortedWallEntities.push({
+                            entity: unsortedEntities[i],
+                            minDiff: Math.min(xDiff, yDiff),
+                        });
+                    }
+                }
+            }
+
+            // Sort array so smallest minDiffs appear first for collisions
+            sortedWallEntities.sort((a, b) => a.minDiff - b.minDiff);
+        }
+        let entities = sortedWallEntities.map(e => e.entity);
 
         // Check for collisions
         // Each entity should have an x, y, and size


### PR DESCRIPTION
I've noticed that the player gets stuck when sliding on the wall in some specific directions. This is caused by the wall collisions being applied in the wrong order, as they simply get applied in the order the walls are defined on the map (left to right and top to bottom).

For example on this representation of a map:
```
          ┌─────────┐
          │         │
          │ Player  │
          │         │
┌─────────┼─────────┼─────────┐
│         │         │         │
│  Wall 1 │  Wall 2 │  Wall 3 │
│         │         │         │
└─────────┴─────────┴─────────┘
```

If the player is moving south west (`↙`), we will evaluate two collisions:
- The collision with `wall1` will be interpreted as being horizontal, which will reset the `X` position.
- The collision with `wall2` will be interpreted as being vertical, which will reset the `Y` position. This collision happens even though the `X` position was reset in the previous step.

This will cause the player to get stuck.

If the player was moving south east (`↘`), something different will happen:
- The collision with `wall2` will be interpreted as being vertical, which will reset the `Y` position.
- As the `Y` position has been reset, `wall3` is not colliding with the player anymore, so it will be skipped.

The fix for this is to make sure we process collisions in the right order. That means processing the collision with `wall2` before the collisions with `wall1` or `wall3`. More generally, we want to handle side collisions before we handle diagonal corner collisions.

To do that, I've split the collision loop into two parts, the first part filters the elements to only the ones that are actually colliding, and sorts them by the minimum of the differences of the X and Y distances between player and wall. The second loop is the same as before.

The reason to sort the values my minimum distance of axis is that when the collision is a diagonal corner hit, we expect both diffs to be very close to `this.size`, while on side collisions it's going to be smaller, in the range of `[0, this.size)`
